### PR TITLE
Fix/judge pyright errors + hf json parsing

### DIFF
--- a/docs/source/core_features/llm_as_a_judge.md
+++ b/docs/source/core_features/llm_as_a_judge.md
@@ -6,8 +6,8 @@ Add a `judge:` block to your RAG config to check retrieval quality before genera
 
 1. Retrieve chunks from the index (Milvus + optional BGE rerank).
 2. Evaluate them in a loop (at most `max_corrective_steps` corrective actions, default `1`):
-  - Proceed without calling the judge LLM if index metrics meet `metric_thresholds`.
-  - Otherwise, call `judge.llm` (or apply `force_corrective_action`) and run the chosen corrective action.
+  - `**PROCEED` without calling the judge LLM** when index metrics meet `metric_thresholds` — retrieval is already considered good enough.
+  - Otherwise, call `judge.llm` and run the chosen corrective action.
   - Repeat on the merged chunks until the judge says `PROCEED` or the step budget is exhausted.
 3. Generate the answer from the final context.
 
@@ -38,9 +38,26 @@ Key settings under `rag.judge`:
 
 - `metric_thresholds` — index minimums (`min_mean_similarity`, `min_max_rerank_score`, `min_num_docs`, …)
 - `max_corrective_steps` — how many corrective actions after the first retrieval
-- `allow_re_retrieve` / `allow_add_questions` / `allow_add_context` — allowed LLM decisions
-- `force_corrective_action` — skip the judge LLM and force an action when thresholds fail (benchmarks); use `PROCEED` for a no-correction baseline
+- `allow_re_retrieve` / `allow_add_questions` / `allow_add_context` — which corrective actions the judge may choose (see below)
 - `system_prompt` / `user_prompt` — judge prompts; user prompt supports `{query}`, `{metrics}`, `{chunks}`, `{allowed_actions}`, and correction-step placeholders
+
+### Using one corrective action
+
+In your RAG config, under `**rag.judge**`, set `allow_re_retrieve`, `allow_add_questions`, and `allow_add_context` so **only one** corrective action is `true` (the others `false`). `PROCEED` is always available in `{allowed_actions}`.
+
+When `**metric_thresholds` are met**, the pipeline `**PROCEEDS` immediately** without calling the judge LLM: index retrieval is already of high quality (similarity, rerank scores, enough documents).
+
+When **thresholds fail**, the judge LLM is invoked. With a single corrective action enabled, it **systematically chooses that action** and fills the matching payload (`extra_questions`, `web_query`, or `retrieve_params`). Use a query suited to that action (multi-part question → `ADD_QUESTIONS`; missing corpus fact → `ADD_CONTEXT`; weak or mis-phrased retrieval → `RE_RETRIEVE`). Adjust `system_prompt` / `user_prompt` under `rag.judge` if needed.
+
+
+| Goal                            | `rag.judge` `allow_`* settings                                                      |
+| ------------------------------- | ----------------------------------------------------------------------------------- |
+| Sub-questions (`ADD_QUESTIONS`) | `allow_add_questions: true`, `allow_add_context: false`, `allow_re_retrieve: false` |
+| Web context (`ADD_CONTEXT`)     | `allow_add_context: true`, `allow_add_questions: false`, `allow_re_retrieve: false` |
+| Re-retrieval (`RE_RETRIEVE`)    | `allow_re_retrieve: true`, `allow_add_questions: false`, `allow_add_context: false` |
+
+
+Examples: `examples/rag/demo/config_add_questions.yaml`, `config_judge_add_questions.yaml`.
 
 For `ADD_CONTEXT`, install web search support:
 

--- a/docs/source/core_features/llm_as_a_judge.md
+++ b/docs/source/core_features/llm_as_a_judge.md
@@ -6,7 +6,7 @@ Add a `judge:` block to your RAG config to check retrieval quality before genera
 
 1. Retrieve chunks from the index (Milvus + optional BGE rerank).
 2. Evaluate them in a loop (at most `max_corrective_steps` corrective actions, default `1`):
-  - `**PROCEED` without calling the judge LLM** when index metrics meet `metric_thresholds` — retrieval is already considered good enough.
+  - **`PROCEED` without calling the judge LLM** when index metrics meet `metric_thresholds` — retrieval is already considered good enough.
   - Otherwise, call `judge.llm` and run the chosen corrective action.
   - Repeat on the merged chunks until the judge says `PROCEED` or the step budget is exhausted.
 3. Generate the answer from the final context.

--- a/examples/rag/config_judge.yaml
+++ b/examples/rag/config_judge.yaml
@@ -80,8 +80,8 @@ rag:
     allow_re_retrieve: true
     max_web_results: 5
     rerank_after_merge: true  # rerank merged on-prem + web/corrective docs with retriever reranker
-    # force_corrective_action: RE_RETRIEVE  # skip judge LLM; force action when thresholds fail
-    # force_corrective_action: PROCEED      # baseline benchmark: no LLM, no correction when thresholds fail
+    # One corrective action: in rag.judge set allow_* so only one is true (see docs llm_as_a_judge.md).
+    # force_corrective_action: PROCEED  # optional benchmark only. It skips judge LLM when thresholds fail
   system_prompt: "Use the following context to answer the questions.\n\nContext:\n{context}"
 mode: local
 mode_args:

--- a/src/mmore/rag/judge/corrective.py
+++ b/src/mmore/rag/judge/corrective.py
@@ -1,7 +1,7 @@
 """Corrective retrieval loop: apply actions and retrieve_with_judge."""
 
 import logging
-from typing import Any, Dict, List
+from typing import Any, Callable, Dict, List, Union, cast
 
 from langchain_core.documents import Document
 
@@ -19,6 +19,18 @@ from .types import JudgeConfig, JudgeDecision, JudgeResult
 
 logger = logging.getLogger(__name__)
 
+RetrieverInput = Union[str, Dict[str, Any]]
+
+
+def _invoke_retriever(
+    retriever: Retriever,
+    query_or_state: RetrieverInput,
+    **kwargs: Any,
+) -> List[Document]:
+    """Invoke retriever with str or RAG state dict (LangChain stubs expect str)."""
+    invoke = cast(Callable[..., List[Document]], retriever.invoke)
+    return invoke(query_or_state, **kwargs)
+
 
 def apply_corrective_action(
     retriever: Retriever,
@@ -32,7 +44,7 @@ def apply_corrective_action(
     if result.decision == JudgeDecision.ADD_QUESTIONS:
         for sub_query in result.extra_questions[:3]:
             sub_state = {**state, "input": sub_query}
-            sub_docs = retriever.invoke(sub_state)
+            sub_docs = _invoke_retriever(retriever, sub_state)
             docs = merge_documents(docs, sub_docs)
 
     elif result.decision == JudgeDecision.ADD_CONTEXT:
@@ -47,7 +59,7 @@ def apply_corrective_action(
             result.retrieve_params, query, retriever.k
         )
         new_state = {**state, "input": effective["input"]}
-        new_docs = retriever.invoke(new_state, k=effective["k"])
+        new_docs = _invoke_retriever(retriever, new_state, k=effective["k"])
         docs = merge_documents(docs, new_docs)
 
     if config.rerank_after_merge and docs:
@@ -71,7 +83,7 @@ def retrieve_with_judge(
 
     Returns state enriched with docs, retrieval_metrics, judge_decision, judge_actions.
     """
-    docs = retriever.invoke(state)
+    docs = _invoke_retriever(retriever, state)
     judge_actions: List[str] = []
     retrieval_corrections: List[Dict[str, Any]] = []
     judge_llm_calls = 0

--- a/src/mmore/rag/judge/decisions.py
+++ b/src/mmore/rag/judge/decisions.py
@@ -69,6 +69,8 @@ def step_record(
         "llm_invoked": result.llm_invoked,
         "context_relevance_score": result.context_relevance_score,
     }
+    if result.llm_invoked and result.raw_llm_response:
+        record["llm_response"] = result.raw_llm_response
     if result.decision == JudgeDecision.ADD_QUESTIONS:
         record["extra_questions"] = list(result.extra_questions)
     elif result.decision == JudgeDecision.ADD_CONTEXT:

--- a/src/mmore/rag/judge/evaluator.py
+++ b/src/mmore/rag/judge/evaluator.py
@@ -11,10 +11,10 @@ from langchain_core.messages import HumanMessage, SystemMessage
 from .decisions import allowed_actions, coerce_decision
 from .metrics import evaluate_metrics
 from .parsing import (
-    _judge_json_snippet,
+    extract_judge_raw_response,
     format_chunks_for_prompt,
     parse_context_relevance_score,
-    parse_json_response,
+    parse_judge_llm_response,
 )
 from .types import JudgeConfig, JudgeDecision, JudgeResult
 
@@ -134,10 +134,8 @@ class LLMJudge:
             ]
         )
 
-        raw_llm_response = _judge_json_snippet(response.content)
-
         try:
-            parsed = parse_json_response(raw_llm_response)
+            raw_llm_response, parsed = parse_judge_llm_response(response.content)
         except (json.JSONDecodeError, TypeError) as e:
             logger.warning(
                 "Failed to parse judge JSON: %s | see judge_steps[].llm_response in output",
@@ -146,7 +144,7 @@ class LLMJudge:
             return JudgeResult.proceed(
                 "parse_error_fallback",
                 llm_invoked=True,
-                raw_llm_response=raw_llm_response,
+                raw_llm_response=extract_judge_raw_response(response.content),
             )
 
         return self._result_from_parsed(parsed, raw_llm_response=raw_llm_response)

--- a/src/mmore/rag/judge/evaluator.py
+++ b/src/mmore/rag/judge/evaluator.py
@@ -11,7 +11,7 @@ from langchain_core.messages import HumanMessage, SystemMessage
 from .decisions import allowed_actions, coerce_decision
 from .metrics import evaluate_metrics
 from .parsing import (
-    extract_llm_text,
+    _judge_json_snippet,
     format_chunks_for_prompt,
     parse_context_relevance_score,
     parse_json_response,
@@ -67,7 +67,11 @@ class LLMJudge:
         return None
 
     def _result_from_parsed(
-        self, parsed: Dict[str, Any], *, llm_invoked: bool = True
+        self,
+        parsed: Dict[str, Any],
+        *,
+        llm_invoked: bool = True,
+        raw_llm_response: Optional[str] = None,
     ) -> JudgeResult:
         decision, coerced, raw = coerce_decision(
             str(parsed.get("decision", JudgeDecision.PROCEED.value)), self.config
@@ -92,6 +96,7 @@ class LLMJudge:
             extra_questions=[str(q) for q in extra_questions],
             web_query=parsed.get("web_query"),
             retrieve_params=parsed.get("retrieve_params"),
+            raw_llm_response=raw_llm_response,
         )
 
     def evaluate(
@@ -129,15 +134,19 @@ class LLMJudge:
             ]
         )
 
-        try:
-            parsed = parse_json_response(extract_llm_text(response.content))
-        except (json.JSONDecodeError, TypeError) as e:
-            raw = extract_llm_text(response.content)
-            logger.warning(
-                "Failed to parse judge JSON: %s | raw=%r",
-                e,
-                raw[:500],
-            )
-            return JudgeResult.proceed("parse_error_fallback", llm_invoked=True)
+        raw_llm_response = _judge_json_snippet(response.content)
 
-        return self._result_from_parsed(parsed)
+        try:
+            parsed = parse_json_response(raw_llm_response)
+        except (json.JSONDecodeError, TypeError) as e:
+            logger.warning(
+                "Failed to parse judge JSON: %s | see judge_steps[].llm_response in output",
+                e,
+            )
+            return JudgeResult.proceed(
+                "parse_error_fallback",
+                llm_invoked=True,
+                raw_llm_response=raw_llm_response,
+            )
+
+        return self._result_from_parsed(parsed, raw_llm_response=raw_llm_response)

--- a/src/mmore/rag/judge/llm.py
+++ b/src/mmore/rag/judge/llm.py
@@ -1,55 +1,20 @@
-"""Judge-specific LLM loading (does not alter the global RAG LLM path)."""
-
-try:
-    import torch
-except ImportError:
-    torch = None
+"""Judge LLM factory — keeps HF judge settings out of the main RAG LLM path."""
 
 from langchain_core.language_models.chat_models import BaseChatModel
-from langchain_huggingface import ChatHuggingFace, HuggingFacePipeline
 
 from ...utils import load_config
 from ..llm import LLM, LLMConfig
 
 
 def judge_llm_from_config(config: str | LLMConfig) -> BaseChatModel:
-    """Load an LLM for judge evaluation.
+    """Load the judge LLM (``judge.llm`` in config).
 
-    HuggingFace pipelines return generation-only output here so JSON parsing
-    stays reliable. All other providers reuse the standard ``LLM.from_config``.
+    Same as ``LLM.from_config`` except HuggingFace models use
+    ``return_full_text=False`` so generation-only output is easier to parse as JSON.
+    Non-HF providers are unchanged.
     """
     if isinstance(config, str):
         config = load_config(config, LLMConfig)
     if config.provider != "HF":
         return LLM.from_config(config)
-
-    if torch is None:
-        raise ImportError(
-            "torch is required for HuggingFace models. "
-            "Install it with: uv pip install 'mmore[cpu]' or uv pip install 'mmore[cu126]'"
-        )
-
-    pipeline_kwargs = {**config.generation_kwargs, "return_full_text": False}
-    if torch.backends.mps.is_available():
-        return ChatHuggingFace(
-            llm=HuggingFacePipeline.from_model_id(
-                model_id=config.llm_name,
-                task="text-generation",
-                device_map="mps",
-                pipeline_kwargs=pipeline_kwargs,
-            )
-        )
-    if torch.cuda.is_available():
-        current_device = LLM.device_count
-        LLM.device_count = (LLM.device_count + 1) % LLM._get_nb_devices()
-    else:
-        current_device = -1
-
-    return ChatHuggingFace(
-        llm=HuggingFacePipeline.from_model_id(
-            config.llm_name,
-            task="text-generation",
-            device=current_device,
-            pipeline_kwargs=pipeline_kwargs,
-        )
-    )
+    return LLM.from_config(config, hf_return_full_text=False)

--- a/src/mmore/rag/judge/llm.py
+++ b/src/mmore/rag/judge/llm.py
@@ -1,0 +1,55 @@
+"""Judge-specific LLM loading (does not alter the global RAG LLM path)."""
+
+try:
+    import torch
+except ImportError:
+    torch = None
+
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_huggingface import ChatHuggingFace, HuggingFacePipeline
+
+from ...utils import load_config
+from ..llm import LLM, LLMConfig
+
+
+def judge_llm_from_config(config: str | LLMConfig) -> BaseChatModel:
+    """Load an LLM for judge evaluation.
+
+    HuggingFace pipelines return generation-only output here so JSON parsing
+    stays reliable. All other providers reuse the standard ``LLM.from_config``.
+    """
+    if isinstance(config, str):
+        config = load_config(config, LLMConfig)
+    if config.provider != "HF":
+        return LLM.from_config(config)
+
+    if torch is None:
+        raise ImportError(
+            "torch is required for HuggingFace models. "
+            "Install it with: uv pip install 'mmore[cpu]' or uv pip install 'mmore[cu126]'"
+        )
+
+    pipeline_kwargs = {**config.generation_kwargs, "return_full_text": False}
+    if torch.backends.mps.is_available():
+        return ChatHuggingFace(
+            llm=HuggingFacePipeline.from_model_id(
+                model_id=config.llm_name,
+                task="text-generation",
+                device_map="mps",
+                pipeline_kwargs=pipeline_kwargs,
+            )
+        )
+    if torch.cuda.is_available():
+        current_device = LLM.device_count
+        LLM.device_count = (LLM.device_count + 1) % LLM._get_nb_devices()
+    else:
+        current_device = -1
+
+    return ChatHuggingFace(
+        llm=HuggingFacePipeline.from_model_id(
+            config.llm_name,
+            task="text-generation",
+            device=current_device,
+            pipeline_kwargs=pipeline_kwargs,
+        )
+    )

--- a/src/mmore/rag/judge/parsing.py
+++ b/src/mmore/rag/judge/parsing.py
@@ -60,12 +60,22 @@ def extract_judge_fields_loose(text: str) -> Dict[str, Any]:
 def _judge_json_snippet(text: Any) -> str:
     """Isolate the judge JSON object (assistant reply, not prompt metrics)."""
     text = extract_llm_text(text).strip()
-    if text.startswith("{"):
+    if not text:
         return text
-    start = text.rfind("{")
-    if start == -1:
-        return text
-    return text[start:]
+
+    decoder = json.JSONDecoder()
+    for i, ch in enumerate(text):
+        if ch != "{":
+            continue
+        try:
+            obj, end = decoder.raw_decode(text[i:])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict) and "decision" in obj:
+            return text[i : i + end]
+
+    start = text.find("{")
+    return text[start:] if start != -1 else text
 
 
 def _parse_json_dict(text: str) -> Dict[str, Any]:

--- a/src/mmore/rag/judge/parsing.py
+++ b/src/mmore/rag/judge/parsing.py
@@ -74,6 +74,13 @@ def _judge_json_snippet(text: Any) -> str:
         if isinstance(obj, dict) and "decision" in obj:
             return text[i : i + end]
 
+    decision_matches = list(re.finditer(r'"decision"\s*:', text, re.IGNORECASE))
+    if decision_matches:
+        decision_pos = decision_matches[-1].start()
+        start = text.rfind("{", 0, decision_pos)
+        if start != -1:
+            return text[start:]
+
     start = text.find("{")
     return text[start:] if start != -1 else text
 
@@ -98,6 +105,10 @@ def _parse_json_dict(text: str) -> Dict[str, Any]:
             obj, _ = json.JSONDecoder().raw_decode(candidate)
             if not isinstance(obj, dict):
                 raise TypeError(f"Expected JSON object, got {type(obj).__name__}")
+            if "decision" not in obj:
+                raise json.JSONDecodeError(
+                    "Parsed JSON object has no decision field", candidate, 0
+                )
             return obj
         except (json.JSONDecodeError, TypeError) as e:
             last_error = e

--- a/src/mmore/rag/judge/parsing.py
+++ b/src/mmore/rag/judge/parsing.py
@@ -41,12 +41,35 @@ def extract_judge_fields_loose(text: str) -> Dict[str, Any]:
         obj["reason"] = m.group(1)
     if m := re.search(r'"sufficient"\s*:\s*(true|false)', text, re.IGNORECASE):
         obj["sufficient"] = m.group(1).lower() == "true"
+    if m := re.search(r'"extra_questions"\s*:\s*(\[[^\]]*\])', text, re.DOTALL):
+        try:
+            extra = json.loads(m.group(1))
+            if isinstance(extra, list):
+                obj["extra_questions"] = [str(q) for q in extra]
+        except json.JSONDecodeError:
+            pass
+    if m := re.search(r'"web_query"\s*:\s*"((?:[^"\\]|\\.)*)"', text):
+        obj["web_query"] = m.group(1)
+    elif re.search(r'"web_query"\s*:\s*null', text):
+        obj["web_query"] = None
     if "decision" not in obj:
         raise json.JSONDecodeError("No decision field found", text, 0)
     return obj
 
 
+def _judge_json_snippet(text: Any) -> str:
+    """Isolate the judge JSON object (assistant reply, not prompt metrics)."""
+    text = extract_llm_text(text).strip()
+    if text.startswith("{"):
+        return text
+    start = text.rfind("{")
+    if start == -1:
+        return text
+    return text[start:]
+
+
 def parse_json_response(text: str) -> Dict[str, Any]:
+    text = _judge_json_snippet(text)
     text = text.strip()
     if text.startswith("```"):
         text = re.sub(r"^```(?:json)?\s*", "", text, flags=re.IGNORECASE)
@@ -79,12 +102,28 @@ def parse_json_response(text: str) -> Dict[str, Any]:
         raise json.JSONDecodeError("Could not parse judge JSON", snippet, 0)
 
 
+_LLAMA_ASSISTANT_DELIMITERS = (
+    "<|eot_id|><|start_header_id|>assistant<|end_header_id|>",
+    "<|eot_id|>assistant",
+    "<|assistant|>",
+)
+_LLAMA_END_MARKERS = ("<|eot_id|>", "<|end_of_text|>")
+
+
 def extract_llm_text(content: Any) -> str:
     if isinstance(content, list):
         content = content[-1] if content else ""
     if isinstance(content, dict):
         content = content.get("content", "")
-    return str(content)
+    text = str(content).strip()
+    for delimiter in _LLAMA_ASSISTANT_DELIMITERS:
+        if delimiter in text:
+            text = text.split(delimiter, 1)[-1]
+            break
+    for end in _LLAMA_END_MARKERS:
+        if end in text:
+            text = text.split(end, 1)[0]
+    return text.strip()
 
 
 def format_chunks_for_prompt(docs: List[Document], max_chunk_chars: int) -> str:

--- a/src/mmore/rag/judge/parsing.py
+++ b/src/mmore/rag/judge/parsing.py
@@ -68,8 +68,7 @@ def _judge_json_snippet(text: Any) -> str:
     return text[start:]
 
 
-def parse_json_response(text: str) -> Dict[str, Any]:
-    text = _judge_json_snippet(text)
+def _parse_json_dict(text: str) -> Dict[str, Any]:
     text = text.strip()
     if text.startswith("```"):
         text = re.sub(r"^```(?:json)?\s*", "", text, flags=re.IGNORECASE)
@@ -100,6 +99,21 @@ def parse_json_response(text: str) -> Dict[str, Any]:
         if last_error is not None:
             raise last_error
         raise json.JSONDecodeError("Could not parse judge JSON", snippet, 0)
+
+
+def parse_judge_llm_response(content: Any) -> tuple[str, Dict[str, Any]]:
+    """Extract the judge JSON snippet and parse it (single preprocessing pass)."""
+    raw = _judge_json_snippet(content)
+    return raw, _parse_json_dict(raw)
+
+
+def extract_judge_raw_response(content: Any) -> str:
+    """Judge JSON snippet for logging when full parsing fails."""
+    return _judge_json_snippet(content)
+
+
+def parse_json_response(text: str) -> Dict[str, Any]:
+    return _parse_json_dict(_judge_json_snippet(text))
 
 
 _LLAMA_ASSISTANT_DELIMITERS = (

--- a/src/mmore/rag/judge/types.py
+++ b/src/mmore/rag/judge/types.py
@@ -105,6 +105,7 @@ class JudgeResult:
     web_query: Optional[str] = None
     retrieve_params: Optional[Dict[str, Any]] = None
     llm_invoked: bool = False
+    raw_llm_response: Optional[str] = None
     raw_decision: Optional[str] = None
     coerced_decision: bool = False
 

--- a/src/mmore/rag/llm.py
+++ b/src/mmore/rag/llm.py
@@ -171,7 +171,12 @@ class LLM(BaseChatModel):
             )
 
     @classmethod
-    def from_config(cls, config: str | LLMConfig) -> BaseChatModel:
+    def from_config(
+        cls,
+        config: str | LLMConfig,
+        *,
+        hf_return_full_text: bool | None = None,
+    ) -> BaseChatModel:
         if isinstance(config, str):
             config = load_config(config, LLMConfig)
 
@@ -181,13 +186,16 @@ class LLM(BaseChatModel):
                     "torch is required for HuggingFace models. "
                     "Install it with: uv pip install 'mmore[cpu]' or uv pip install 'mmore[cu126]'"
                 )
+            pipeline_kwargs = dict(config.generation_kwargs)
+            if hf_return_full_text is not None:
+                pipeline_kwargs["return_full_text"] = hf_return_full_text
             if torch.backends.mps.is_available():
                 return ChatHuggingFace(
                     llm=HuggingFacePipeline.from_model_id(
                         model_id=config.llm_name,
                         task="text-generation",
                         device_map="mps",
-                        pipeline_kwargs=config.generation_kwargs,
+                        pipeline_kwargs=pipeline_kwargs,
                     )
                 )
             if torch.cuda.is_available():
@@ -201,7 +209,7 @@ class LLM(BaseChatModel):
                     config.llm_name,
                     task="text-generation",
                     device=current_device,
-                    pipeline_kwargs=config.generation_kwargs,
+                    pipeline_kwargs=pipeline_kwargs,
                 )
             )
         else:

--- a/src/mmore/rag/pipeline.py
+++ b/src/mmore/rag/pipeline.py
@@ -15,6 +15,7 @@ from langchain_core.runnables import Runnable, RunnableLambda, RunnablePassthrou
 
 from ..utils import load_config
 from .judge import JUDGE_OUTPUT_KEYS, JudgeConfig, LLMJudge, retrieve_with_judge
+from .judge.llm import judge_llm_from_config
 from .llm import LLM, LLMConfig
 from .retriever import Retriever, RetrieverConfig
 from .types import MMOREInput, MMOREOutput
@@ -73,7 +74,7 @@ class RAGPipeline:
         retriever = Retriever.from_config(config.retriever)
         llm = LLM.from_config(config.llm)
         judge = (
-            LLMJudge(llm=LLM.from_config(config.judge.llm), config=config.judge)
+            LLMJudge(llm=judge_llm_from_config(config.judge.llm), config=config.judge)
             if config.judge
             else None
         )

--- a/src/mmore/rag/retriever.py
+++ b/src/mmore/rag/retriever.py
@@ -13,6 +13,7 @@ from langchain_core.callbacks import CallbackManagerForRetrieverRun
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
 from langchain_core.retrievers import BaseRetriever
+from langchain_core.runnables import RunnableConfig
 from langchain_milvus.utils.sparse import BaseSparseEmbedding
 from pymilvus import AnnSearchRequest, MilvusClient, WeightedRanker
 from transformers import AutoModelForSequenceClassification, AutoTokenizer
@@ -309,6 +310,15 @@ class Retriever(BaseRetriever):
             doc.metadata["rank"] = rank_i
             reranked.append(doc)
         return reranked
+
+    def invoke(
+        self,
+        input: str | Dict[str, Any],
+        config: Optional[RunnableConfig] = None,
+        **kwargs: Any,
+    ) -> List[Document]:
+        """Accept a query string or RAG state dict with an ``input`` key."""
+        return super().invoke(input, config, **kwargs)
 
     def _get_relevant_documents(
         self,

--- a/src/mmore/rag/retriever.py
+++ b/src/mmore/rag/retriever.py
@@ -13,7 +13,6 @@ from langchain_core.callbacks import CallbackManagerForRetrieverRun
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
 from langchain_core.retrievers import BaseRetriever
-from langchain_core.runnables import RunnableConfig
 from langchain_milvus.utils.sparse import BaseSparseEmbedding
 from pymilvus import AnnSearchRequest, MilvusClient, WeightedRanker
 from transformers import AutoModelForSequenceClassification, AutoTokenizer
@@ -310,15 +309,6 @@ class Retriever(BaseRetriever):
             doc.metadata["rank"] = rank_i
             reranked.append(doc)
         return reranked
-
-    def invoke(
-        self,
-        input: str | Dict[str, Any],
-        config: Optional[RunnableConfig] = None,
-        **kwargs: Any,
-    ) -> List[Document]:
-        """Accept a query string or RAG state dict with an ``input`` key."""
-        return super().invoke(input, config, **kwargs)
 
     def _get_relevant_documents(
         self,

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -212,6 +212,16 @@ def test_parse_json_repairs_trailing_comma_and_python_literals():
     assert p["sufficient"] is True
 
 
+def test_parse_json_nested_retrieve_params_with_prefix():
+    raw = (
+        'Summary: {"k": 10}\n'
+        '{"decision":"RE_RETRIEVE","retrieve_params":{"k":10},"reason":"weak"}'
+    )
+    parsed = parse_json_response(raw)
+    assert parsed["decision"] == "RE_RETRIEVE"
+    assert parsed["retrieve_params"] == {"k": 10}
+
+
 @pytest.mark.parametrize(
     "cfg_kw,docs,llm_json,invoke,decision,reason_sub,extra",
     [

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -222,6 +222,13 @@ def test_parse_json_nested_retrieve_params_with_prefix():
     assert parsed["retrieve_params"] == {"k": 10}
 
 
+def test_parse_json_valid_prefix_and_invalid_decision_block():
+    raw = 'Summary: {"k": 10}\n{"decision":"RE_RETRIEVE","context_relevance_score":4,}'
+    parsed = parse_json_response(raw)
+    assert parsed["decision"] == "RE_RETRIEVE"
+    assert parsed["context_relevance_score"] == 4
+
+
 @pytest.mark.parametrize(
     "cfg_kw,docs,llm_json,invoke,decision,reason_sub,extra",
     [

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -8,6 +8,7 @@ from langchain_core.documents import Document
 
 from mmore.rag.judge import (
     JUDGE_OUTPUT_KEYS,
+    JudgeConfig,
     JudgeDecision,
     JudgeResult,
     LLMJudge,
@@ -25,7 +26,9 @@ from mmore.rag.judge.parsing import extract_llm_text
 from mmore.run_rag import RAGInferenceConfig
 from mmore.utils import load_config
 
-_CFG = load_config("examples/rag/config_judge.yaml", RAGInferenceConfig).rag.judge
+_inference_cfg = load_config("examples/rag/config_judge.yaml", RAGInferenceConfig)
+assert _inference_cfg.rag is not None and _inference_cfg.rag.judge is not None
+_CFG: JudgeConfig = _inference_cfg.rag.judge
 _THRESH = _CFG.metric_thresholds
 
 

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -21,6 +21,7 @@ from mmore.rag.judge import (
     retrieve_with_judge,
 )
 from mmore.rag.judge.corrective import apply_corrective_action
+from mmore.rag.judge.parsing import extract_llm_text
 from mmore.run_rag import RAGInferenceConfig
 from mmore.utils import load_config
 
@@ -160,6 +161,45 @@ def test_metrics_thresholds_merge_and_correction_record():
 def test_coerce_decision_fallback(cfg_kw, raw, expected):
     decision, _, raw_decision = coerce_decision(raw, _cfg(**cfg_kw))
     assert decision == expected and raw_decision == raw
+
+
+def test_parse_json_from_full_llama_response():
+    raw = (
+        "Retrieval metrics: {'num_docs': 5.0}\n"
+        "Allowed actions: ['PROCEED', 'ADD_QUESTIONS']\n"
+        "<|eot_id|>assistant\n\n"
+        '{"decision":"ADD_QUESTIONS","extra_questions":["q1","q2"],"reason":"split"}'
+    )
+    parsed = parse_json_response(raw)
+    assert parsed["decision"] == "ADD_QUESTIONS"
+    assert parsed["extra_questions"] == ["q1", "q2"]
+
+
+def test_extract_llm_text_strips_llama_chat_template():
+    raw = (
+        "<|begin_of_text|>systemYou are a judge.<|eot_id|>"
+        "userQuestion?<|eot_id|>assistant"
+        '{"decision":"ADD_QUESTIONS","extra_questions":["q1"]}'
+        "<|eot_id|>"
+    )
+    assert (
+        extract_llm_text(raw) == '{"decision":"ADD_QUESTIONS","extra_questions":["q1"]}'
+    )
+
+
+def test_step_record_includes_llm_response():
+    from mmore.rag.judge.decisions import step_record
+
+    result = JudgeResult(
+        decision=JudgeDecision.ADD_QUESTIONS,
+        extra_questions=["q1"],
+        llm_invoked=True,
+        raw_llm_response='{"decision":"ADD_QUESTIONS","extra_questions":["q1"]}',
+        exit_reason="llm_corrective",
+    )
+    record = step_record(0, result, "main query", 5)
+    assert record["llm_response"] == result.raw_llm_response
+    assert record["extra_questions"] == ["q1"]
 
 
 def test_parse_json_repairs_trailing_comma_and_python_literals():


### PR DESCRIPTION
This PR fixes judge LLM response parsing for local HuggingFace and Llama models without changing the normal RAG generation path.

Judge parsing now strips Llama chat template tokens and picks the correct JSON object when prompt noise or retrieval metrics appear before the decision block. On parse failure the judge falls back to PROCEED with parse_error_fallback instead of crashing. When the judge LLM is invoked, the raw response is stored in judge_steps llm_response for debugging.

HuggingFace judge models are loaded with return_full_text=False through judge_llm_from_config, using an optional parameter on LLM.from_config. The main RAG LLM loaded from rag.llm is unchanged.

Pyright issues in test_judge.py and corrective.py are addressed with proper typing and a local cast for retriever.invoke with state dicts.